### PR TITLE
chore(next.config.js): configure headers to avoid logged areas to be iframed

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,4 +5,17 @@ module.exports = {
   async redirects() {
     return redirects;
   },
+  async headers() {
+    return [
+      {
+        source: '/app/:path*/',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+        ],
+      },
+    ];
+  },
 };


### PR DESCRIPTION
Configuração para não permitir que a área logada seja usada em um iframe