### PR TITLE
M05a02 trazendo conteudo do dato cms e entendendo buscas no graph ql

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,4 +83,7 @@ jobs:
         run: yarn --prefer-offline
 
       - name: Run Integration Tests
+        env:
+          NEXT_PUBLIC_DATOCMS_KEY: ${{ secrets.NEXT_PUBLIC_DATOCMS_KEY }}
+          NEXT_PUBLIC_DATOCMS_URL: ${{ secrets.NEXT_PUBLIC_DATOCMS_URL }}
         run: yarn test:integration:build 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,3 +4,4 @@
 
 yarn lint
 yarn test
+yarn test:integration:build

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "@crello/react-lottie": "^0.0.11",
     "framer-motion": "^4.1.17",
+    "graphql": "^15.6.0",
+    "graphql-request": "^3.5.0",
     "lodash": "^4.17.21",
     "next": "latest",
     "nookies": "^2.5.2",

--- a/pages/sobre.js
+++ b/pages/sobre.js
@@ -1,21 +1,47 @@
 import React from 'react';
-import styled from 'styled-components';
 import Box from '../src/components/foundation/layout/Box';
+import Grid from '../src/components/foundation/layout/Grid';
+import Text from '../src/components/foundation/Text';
 import websitePageHOC from '../src/components/wrappers/WebsitePage/hoc';
 
-const Title = styled.h1`
-  text-align: center;
-`;
-
-function AboutPage() {
+function AboutScreen() {
   return (
     <Box
       display="flex"
       flexDirection="column"
-      flex="1"
+      flex={1}
     >
-      <Title>Sobre</Title>
+      <Grid.Container>
+        <Grid.Row
+          marginTop={{ xs: '32px', md: '120px ' }}
+          flex="1"
+        >
+          <Grid.Col
+            value={{ xs: 12, md: 6, lg: 6 }}
+            offset={{ md: 2 }}
+            flex={1}
+          >
+            <Text
+              variant="title"
+              tag="h2"
+              color="tertiary.main"
+            >
+              Página Sobre
+            </Text>
+
+            <Box>
+              Conteúdo da página sobre
+            </Box>
+          </Grid.Col>
+        </Grid.Row>
+      </Grid.Container>
     </Box>
+  );
+}
+
+function AboutPage() {
+  return (
+    <AboutScreen />
   );
 }
 
@@ -23,6 +49,13 @@ export default websitePageHOC(AboutPage, {
   pageWrapperProps: {
     seoProps: {
       headTitle: 'Sobre',
+    },
+    pageBoxProps: {
+      flexWrap: 'wrap',
+      justifyContent: 'space-between',
+      backgroundImage: 'url(/images/bubbles.svg)',
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: 'bottom right',
     },
   },
 });

--- a/pages/sobre.js
+++ b/pages/sobre.js
@@ -1,49 +1,15 @@
 import React from 'react';
-import Box from '../src/components/foundation/layout/Box';
-import Grid from '../src/components/foundation/layout/Grid';
-import Text from '../src/components/foundation/Text';
+import { GraphQLClient, gql } from 'graphql-request';
+import AboutScreen from '../src/components/screens/AbouScreen';
 import websitePageHOC from '../src/components/wrappers/WebsitePage/hoc';
 
-function AboutScreen() {
+function AboutPage({ messages }) {
   return (
-    <Box
-      display="flex"
-      flexDirection="column"
-      flex={1}
-    >
-      <Grid.Container>
-        <Grid.Row
-          marginTop={{ xs: '32px', md: '120px ' }}
-          flex="1"
-        >
-          <Grid.Col
-            value={{ xs: 12, md: 6, lg: 6 }}
-            offset={{ md: 2 }}
-            flex={1}
-          >
-            <Text
-              variant="title"
-              tag="h2"
-              color="tertiary.main"
-            >
-              Página Sobre
-            </Text>
-
-            <Box>
-              Conteúdo da página sobre
-            </Box>
-          </Grid.Col>
-        </Grid.Row>
-      </Grid.Container>
-    </Box>
+    <AboutScreen messages={messages} />
   );
 }
 
-function AboutPage() {
-  return (
-    <AboutScreen />
-  );
-}
+AboutPage.propTypes = AboutScreen.propTypes;
 
 export default websitePageHOC(AboutPage, {
   pageWrapperProps: {
@@ -59,3 +25,32 @@ export default websitePageHOC(AboutPage, {
     },
   },
 });
+
+export async function getStaticProps() {
+  const TOKEN = process.env.NEXT_PUBLIC_DATOCMS_KEY;
+
+  const DatoCMSURL = process.env.NEXT_PUBLIC_DATOCMS_URL;
+
+  const client = new GraphQLClient(DatoCMSURL, {
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+    },
+  });
+
+  const query = gql`
+    query {
+      pageSobre(locale: pt_BR) {
+        pageTitle
+        pageDescription
+      }
+    }
+  `;
+
+  const messages = await client.request(query);
+
+  return {
+    props: {
+      messages,
+    },
+  };
+}

--- a/src/components/screens/AbouScreen/index.js
+++ b/src/components/screens/AbouScreen/index.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Box from '../../foundation/layout/Box';
+import Grid from '../../foundation/layout/Grid';
+import Text from '../../foundation/Text';
+
+export default function AboutScreen({ messages }) {
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      flex={1}
+    >
+      <Grid.Container>
+        <Grid.Row
+          marginTop={{ xs: '32px', md: '120px ' }}
+          flex="1"
+        >
+          <Grid.Col
+            value={{ xs: 12, md: 6, lg: 6 }}
+            offset={{ md: 2 }}
+            flex={1}
+          >
+            <Text
+              variant="title"
+              tag="h2"
+              color="tertiary.main"
+            >
+              {messages.pageSobre.pageTitle}
+            </Text>
+
+            <Box
+              dangerouslySetInnerHTML={{
+                __html: messages.pageSobre.pageDescription,
+              }}
+            />
+          </Grid.Col>
+        </Grid.Row>
+      </Grid.Container>
+    </Box>
+  );
+}
+
+AboutScreen.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  messages: PropTypes.object.isRequired,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,6 +2324,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-fetch@^3.0.6:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -3240,6 +3247,11 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
+extract-files@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
+  integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
+
 extract-zip@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
@@ -3681,6 +3693,20 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+graphql-request@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-3.5.0.tgz#7e69574e15875fb3f660a4b4be3996ecd0bbc8b7"
+  integrity sha512-Io89QpfU4rqiMbqM/KwMBzKaDLOppi8FU8sEccCE4JqCgz95W9Q8bvxQ4NfPALLSMvg9nafgg8AkYRmgKSlukA==
+  dependencies:
+    cross-fetch "^3.0.6"
+    extract-files "^9.0.0"
+    form-data "^3.0.0"
+
+graphql@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.6.0.tgz#e69323c6a9780a1a4b9ddf7e35ca8904bb04df02"
+  integrity sha512-WJR872Zlc9hckiEPhXgyUftXH48jp2EjO5tgBBOyNMRJZ9fviL2mJBD6CAysk6N5S0r9BTs09Qk39nnJBkvOXQ==
 
 har-schema@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Adição das libs graphql e grapql-request para consumir APIs GraphQL
- Criação componente AboutScreen para renderizar dados da tela Sobre
- Refatoração da página Sobre para buscar dados do DatoCMS e renderizar e passar para AboutScreen
- Adição de execução de testes de integração no hook pre-push do husky
- Uso de secrets no job de testes de integração no Github Actions CI para buildar as páginas corretamente