### PR TITLE
M05a04 acessando o cms sem prop drill mais modo preview com lambdas

### DIFF
--- a/pages/api/exit-preview.js
+++ b/pages/api/exit-preview.js
@@ -1,0 +1,7 @@
+export default function handler(req, res) {
+  res.clearPreviewData();
+
+  res.writeHead(307, { location: '/' });
+
+  return res.end();
+}

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -1,0 +1,14 @@
+export default function handler(req, res) {
+  res.setPreviewData({});
+
+  const key = process.env.PREVIEW_KEY;
+
+  if (!key || req.query.key !== key) {
+    res.clearPreviewData({});
+    return res.status(401).json({ message: 'Invalid Key to enable preview' });
+  }
+
+  res.writeHead(307, { location: '/' });
+
+  return res.end();
+}

--- a/pages/sobre.js
+++ b/pages/sobre.js
@@ -25,8 +25,8 @@ export default websitePageHOC(AboutPage, {
   },
 });
 
-export async function getStaticProps() {
-  const messages = await getContent();
+export async function getStaticProps({ preview }) {
+  const messages = await getContent({ preview });
 
   return {
     props: {

--- a/src/components/foundation/Text/index.js
+++ b/src/components/foundation/Text/index.js
@@ -6,6 +6,7 @@ import get from 'lodash/get';
 import Link from '../../commons/Link';
 import propToStyle from '../../../theme/utils/propToStyle';
 import breakpointsMedia from '../../../theme/utils/breakpointsMedia';
+import WebsitePageContext from '../../wrappers/WebsitePage/context';
 
 export const TextStyleVariantsMap = {
   title: css`
@@ -59,8 +60,15 @@ export default function Text({
   variant,
   children,
   href,
+  cmsKey,
   ...props
 }) {
+  const websitePageContext = React.useContext(WebsitePageContext);
+
+  const componentContent = cmsKey
+    ? websitePageContext.getCMSContent(cmsKey)
+    : children;
+
   return href
     ? (
       <TextBase
@@ -70,7 +78,7 @@ export default function Text({
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       >
-        {children}
+        {componentContent}
       </TextBase>
     )
     : (
@@ -80,7 +88,7 @@ export default function Text({
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       >
-        {children}
+        {componentContent}
       </TextBase>
     );
 }
@@ -97,6 +105,7 @@ Text.propTypes = {
   ]),
   children: PropTypes.node,
   href: PropTypes.string,
+  cmsKey: PropTypes.string,
 };
 
 Text.defaultProps = {
@@ -104,6 +113,7 @@ Text.defaultProps = {
   variant: 'paragraph1',
   children: null,
   href: '',
+  cmsKey: undefined,
 };
 
 // p1

--- a/src/components/screens/AbouScreen/getContent.js
+++ b/src/components/screens/AbouScreen/getContent.js
@@ -1,6 +1,6 @@
 import { CMSGraphQLClient, gql } from '../../../infra/cms/CMSGraphQLClient';
 
-export default async function getContent() {
+export default async function getContent({ preview }) {
   const query = gql`
     query {
       pageSobre(locale: pt_BR) {
@@ -10,7 +10,7 @@ export default async function getContent() {
     }
   `;
 
-  const client = CMSGraphQLClient();
+  const client = CMSGraphQLClient({ preview });
 
   const response = await client.query({ query });
 

--- a/src/components/screens/AbouScreen/index.js
+++ b/src/components/screens/AbouScreen/index.js
@@ -28,9 +28,8 @@ export default function AboutScreen({ messages }) {
               variant="title"
               tag="h2"
               color="tertiary.main"
-            >
-              {messages.pageSobre.pageTitle}
-            </Text>
+              cmsKey="pageSobre.pageTitle"
+            />
 
             <Box
               dangerouslySetInnerHTML={{

--- a/src/components/wrappers/WebsitePage/context/index.js
+++ b/src/components/wrappers/WebsitePage/context/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+const WebsitePageContext = React.createContext({
+  toggleModalCadastro: () => { },
+  getCMSContent: () => { },
+});
+
+export default WebsitePageContext;

--- a/src/components/wrappers/WebsitePage/hoc/index.js
+++ b/src/components/wrappers/WebsitePage/hoc/index.js
@@ -14,6 +14,7 @@ export default function websitePageHOC(
       <WebsitePageWrapper
         {...pageWrapperProps}
         {...props.pageWrapperProps}
+        messages={props.messages}
       >
         <PageComponent {...props} />
       </WebsitePageWrapper>

--- a/src/components/wrappers/WebsitePage/index.js
+++ b/src/components/wrappers/WebsitePage/index.js
@@ -1,22 +1,23 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash/get';
 import Box from '../../foundation/layout/Box';
 import Footer from '../../commons/Footer';
 import Menu from '../../commons/Menu';
 import Modal from '../../commons/Modal';
 import FormCadastro from '../../patterns/FormCadastro';
 import SEO from '../../commons/SEO';
+import WebsitePageContext from './context';
 
-export const WebsitePageContext = React.createContext({
-  toggleModalCadastro: () => {},
-});
+export { WebsitePageContext };
 
 export default function WebsitePageWrapper({
   children,
   seoProps,
   pageBoxProps,
   menuProps,
+  messages,
 }) {
   const [isModalOpen, setModalState] = React.useState(false);
 
@@ -26,6 +27,7 @@ export default function WebsitePageWrapper({
         toggleModalCadastro: () => {
           setModalState(!isModalOpen);
         },
+        getCMSContent: (cmsKey) => get(messages, cmsKey),
       }}
     >
       <SEO
@@ -69,6 +71,7 @@ WebsitePageWrapper.defaultProps = {
   menuProps: {
     display: true,
   },
+  messages: {},
 };
 
 WebsitePageWrapper.propTypes = {
@@ -86,4 +89,6 @@ WebsitePageWrapper.propTypes = {
   menuProps: PropTypes.shape({
     display: PropTypes.bool,
   }),
+  // eslint-disable-next-line react/forbid-prop-types
+  messages: PropTypes.object,
 };

--- a/src/infra/cms/CMSGraphQLClient.js
+++ b/src/infra/cms/CMSGraphQLClient.js
@@ -2,8 +2,11 @@ import { GraphQLClient, gql as GraphQLTag } from 'graphql-request';
 
 export const gql = GraphQLTag;
 
-export function CMSGraphQLClient() {
-  const DatoCMSURL = process.env.NEXT_PUBLIC_DATOCMS_URL;
+export function CMSGraphQLClient({ preview } = { preview: false }) {
+  const envUrl = process.env.NEXT_PUBLIC_DATOCMS_URL;
+  const DatoCMSURL = preview
+    ? `${envUrl}preview`
+    : envUrl;
   const TOKEN = process.env.DATO_CMS_TOKEN;
   const client = new GraphQLClient(DatoCMSURL, {
     headers: {


### PR DESCRIPTION
- Adição de API Routes (funções lambda) para ativar/desativar modo Preview do Next
- Modo preview para página Sobre
- Alteração do componente Text para renderizar texto a partir da prop cmsKey
- Passagem do dados da página Sobre para contexto do WebsitePage para renderizar titulo via componente Text
