### PR TITLE
ci(gh-action): add env variable to skip e2e test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,17 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest # The type of runner that the job will run on
     steps: # Steps represent a sequence of tasks that will be executed as part of the job
+      - name: Set env E2E Tests
+        env:
+          E2E_TESTS: ${{ secrets.E2E_TESTS }}
+        run: |
+          echo "E2E_TESTS=$E2E_TESTS" >> "$GITHUB_ENV"     
+      - name: Skip E2E Tests?
+        if: env.E2E_TESTS != 'true'
+        run: |
+          echo "$E2E_TESTS"
+          exit 0
+
       # [Pre Build-step]
       - uses: actions/checkout@v2 ## Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/setup-node@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,18 +72,22 @@ jobs:
       - name: Skip E2E Tests?
         if: env.E2E_TESTS != 'true'
         run: |
-          echo "$E2E_TESTS"
+          echo "Abortando a execução do demais passos por configuração"
           exit 0
 
       # [Pre Build-step]
       - uses: actions/checkout@v2 ## Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+        if: env.E2E_TESTS != 'true'
       - uses: actions/setup-node@v1
+        if: env.E2E_TESTS != 'true'
         with:
           node-version: '14.17.1'
       - name: Get yarn cache directory path
+        if: env.E2E_TESTS != 'true'
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2
+        if: env.E2E_TESTS != 'true'
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -91,9 +95,11 @@ jobs:
 
       # Commands that will run:
       - name: Install Packages
+        if: env.E2E_TESTS != 'true'
         run: yarn --prefer-offline
 
       - name: Run Integration Tests
+        if: env.E2E_TESTS != 'true'
         env:
           DATO_CMS_TOKEN: ${{ secrets.DATO_CMS_TOKEN }}
           NEXT_PUBLIC_DATOCMS_URL: ${{ secrets.NEXT_PUBLIC_DATOCMS_URL }}


### PR DESCRIPTION
add environment variable to github secrets and retrieve it on integration test job to check if it needs to be executed or not